### PR TITLE
Filter out double values with NaN

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ module.exports = function(app) {
                 Time: `${point.timestamp}`
             };
         });
+
+        // filter out NaN double values as they cause Timestream to reject the batch
+        records = records.filter((r) => (r.MeasureValueType != 'DOUBLE' || !Number.isNaN(Number(r.MeasureValue))));
+
         // TODO: this assumes self only
         let common_attributes = {
             TimeUnit: "MILLISECONDS",


### PR DESCRIPTION
I have seen issues where in certain cases my GPS coordinates where NaN - which causes Timestream to reject the entire batch of values. 

Filtering is done after initial filtering in line 60 to allow for type to be determined and only filter out DOUBLE values that are NaN.